### PR TITLE
Hide reading progress track

### DIFF
--- a/src/components/ReadingProgress.astro
+++ b/src/components/ReadingProgress.astro
@@ -70,7 +70,7 @@
     left: 0;
     z-index: 60;
     height: 0.1875rem;
-    background: var(--app-border);
+    background: transparent;
     pointer-events: none;
   }
 


### PR DESCRIPTION
## What changed

- Made the reading progress track transparent so only the filled progress bar is visible.

## Validation

- Ran `npx prettier --check --ignore-unknown src/components/ReadingProgress.astro`.
- Ran `npm run build`.
- Verified in browser that the track is transparent and the fill remains visible while scrolling.