### PR TITLE
Migrate site identity to omereshone.com

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for dominuskelvin.dev
+# Copilot Instructions for omereshone.com
 
 ## Project Overview
 
@@ -9,7 +9,6 @@ Personal website for Kelvin Omereshone built with Astro v3, featuring blog posts
 ### Dual Content Systems
 
 1. **Blog Posts** (`src/pages/blog/*.{md,mdx}`) - Self-hosted content using frontmatter with layout reference
-
    - Uses `Astro.glob('./blog/*.{md,mdx}')` for discovery
    - Layout: `src/layouts/BlogPost.astro`
    - Frontmatter: `layout`, `title`, `description`, `pubDate`, `heroImage`, optional `draft` flag

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kelvin Omereshone's website
 
-This is the repo of [dominuskelvin.dev](https://dominuskelvin.dev) which is the personal website of [Kelvin Omereshone](https://dominuskelvin.dev)
+This is the repo of [omereshone.com](https://omereshone.com) which is the personal website of [Kelvin Omereshone](https://omereshone.com)
 
 ## Why is this repo open source
 
@@ -18,8 +18,8 @@ You can use this repo as inspiration or just fork it to make your own website
 
 ### Contributors
 
-<a href="https://github.com/DominusKelvin/dominuskelvin.dev/graphs/contributors">
+<a href="https://github.com/DominusKelvin/omereshone.com/graphs/contributors">
   <p align="center">
-    <img  src="https://contrib.rocks/image?repo=DominusKelvin/dominuskelvin.dev" alt="A table of avatars from the project's contributors" />
+    <img  src="https://contrib.rocks/image?repo=DominusKelvin/omereshone.com" alt="A table of avatars from the project's contributors" />
   </p>
 </a>

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import vue from '@astrojs/vue'
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://dominuskelvin.dev',
+  site: 'https://omereshone.com',
   integrations: [mdx(), sitemap(), vue()],
   vite: {
     plugins: [tailwindcss()],
@@ -14,7 +14,7 @@ export default defineConfig({
   redirects: {
     '/yt': 'https://youtube.com/@dominuskelvin',
     '/x': 'https://x.com/Dominus_Kelvin',
-    '/nl': 'https://newsletter.dominuskelvin.dev',
+    '/nl': 'https://newsletter.omereshone.com',
     '/gh': 'https://github.com/DominusKelvin',
     '/in': 'https://linkedin.com/in/kelvinomereshone',
     '/ghs': 'https://github.com/sponsors/DominusKelvin',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dominuskelvin",
+  "name": "omereshone.com",
   "version": "4.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dominuskelvin",
+      "name": "omereshone.com",
       "version": "4.4.1",
       "dependencies": {
         "@astrojs/mdx": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dominuskelvin",
+  "name": "omereshone.com",
   "version": "4.4.1",
   "private": true,
   "scripts": {

--- a/public/funding.json
+++ b/public/funding.json
@@ -7,7 +7,7 @@
     "email": "koo@hey.com",
     "description": "Lead maintainer of Sails and creator of The Boring JavaScript Stack. Helping developers build business on JavaScript by providing free and open source tools. Teaching fullstack JavaScript for web development.",
     "webpageUrl": {
-      "url": "https://dominuskelvin.dev"
+      "url": "https://omereshone.com"
     }
   },
   "projects": [

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -29,7 +29,7 @@ const { title, description, image = '/social.png' } = Astro.props
 <script
   src="https://cdn.usefathom.com/script.js"
   data-site="ENXESNYH"
-  data-included-domains="dominuskelvin.dev"
+  data-included-domains="omereshone.com"
   defer></script>
 
 <!-- Primary Meta Tags -->

--- a/src/pages/blog/14-mistakes-beginning-software-developers-make.md
+++ b/src/pages/blog/14-mistakes-beginning-software-developers-make.md
@@ -91,7 +91,7 @@ Take the time to learn you language be it JavaScript, PHP, Rust, really know the
 
 ### Suggestion
 
-There are concepts, patterns and nuances that are unique to your language of programming. Do learn them, it gives depth to your [expressiveness](https://dominuskelvin.dev/blog/expressiveness). Learning your language would give you options to chose from when solving problems with them.
+There are concepts, patterns and nuances that are unique to your language of programming. Do learn them, it gives depth to your [expressiveness](https://omereshone.com/blog/expressiveness). Learning your language would give you options to chose from when solving problems with them.
 
 ## Mistake #9 - Not learning patterns and solutions
 

--- a/src/pages/blog/agency-is-what-you-need.md
+++ b/src/pages/blog/agency-is-what-you-need.md
@@ -36,7 +36,7 @@ Agency is doing, not describing. Building, not planning. Shipping, not announcin
 
 Here's the uncomfortable truth: AI is democratizing intelligence and skill at a pace we've never seen before.
 
-As I laid out in [my previous piece](/blog/ai-will-take-your-job), AI-assisted coding tools like [Warp](https://warp.dev?utm_source=dominuskelvin.dev/blog) can already write mediocre code better and faster than junior engineers. They can explain complex systems, suggest architectural approaches, and generate solutions across multiple domains.
+As I laid out in [my previous piece](/blog/ai-will-take-your-job), AI-assisted coding tools like [Warp](https://warp.dev?utm_source=omereshone.com/blog) can already write mediocre code better and faster than junior engineers. They can explain complex systems, suggest architectural approaches, and generate solutions across multiple domains.
 
 **Intelligence, in the traditional sense, is becoming a commodity.**
 
@@ -66,11 +66,11 @@ Not because I'm brilliant. Because I act.
 
 - When Sails.js needed better tooling, I didn't wait for someone smarter—I shipped [Sails Language Server](https://github.com/sailshq/language-tools) and the [official Sails VS Code extension](https://marketplace.visualstudio.com/items?itemName=Sails.sails-vscode).
 
-- When developers needed to learn fullstack JavaScript, I created [Sailscasts](https://sailscasts.com/courses?utm_source=dominuskelvin.dev), taught courses, wrote [documentation](https://docs.sailscasts.com), and built a [community](https://sailscasts.com/chat).
+- When developers needed to learn fullstack JavaScript, I created [Sailscasts](https://sailscasts.com/courses?utm_source=omereshone.com), taught courses, wrote [documentation](https://docs.sailscasts.com), and built a [community](https://sailscasts.com/chat).
 
 - When African engineering excellence wasn't being covered by mainstream media, I launched [The African Engineer](https://africanengineer.com) to amplify their voices.
 
-- When I needed to get invoices out, I built [Hagfish](https://hagfish.io?utm_source=dominuskelvin.dev) instead of wrestling with clunky tools.
+- When I needed to get invoices out, I built [Hagfish](https://hagfish.io?utm_source=omereshone.com) instead of wrestling with clunky tools.
 
 None of these required genius. They required **showing up and doing the work**.
 
@@ -82,7 +82,7 @@ That's agency. Not talking about it. Not planning it to perfection. Making it.
 
 ## AI As a Force Multiplier
 
-Here's where it gets interesting: tools like [Warp](https://warp.dev?utm_source=dominuskelvin.dev/blog) don't replace agency—they multiply it.
+Here's where it gets interesting: tools like [Warp](https://warp.dev?utm_source=omereshone.com/blog) don't replace agency—they multiply it.
 
 When I use Warp's AI-powered terminal, I'm not outsourcing my thinking. I'm **accelerating my execution**. I can:
 

--- a/src/pages/blog/ai-will-take-your-job.md
+++ b/src/pages/blog/ai-will-take-your-job.md
@@ -20,7 +20,7 @@ The Model T wasn't better because it was more elegant or more capable in every s
 
 I was wrong.
 
-For months I was one of those well-intentioned voices saying, "AI won't replace engineers, it's just a tool to augment us." I wanted to believe it. I still want to believe it. But after spending substantial time building with AI-assisted coding tools like [Warp](https://warp.dev?utm_source=dominuskelvin.dev/blog), I can no longer ignore the economic reality staring me in the face.
+For months I was one of those well-intentioned voices saying, "AI won't replace engineers, it's just a tool to augment us." I wanted to believe it. I still want to believe it. But after spending substantial time building with AI-assisted coding tools like [Warp](https://warp.dev?utm_source=omereshone.com/blog), I can no longer ignore the economic reality staring me in the face.
 
 Anyone who claims AI won't replace engineers in most tasks, though well-intentioned, is completely wrong.
 

--- a/src/pages/blog/rewriting-my-website-with-astro.md
+++ b/src/pages/blog/rewriting-my-website-with-astro.md
@@ -63,7 +63,7 @@ Astro claimed to be [fast by default](https://docs.astro.build/en/concepts/why-a
 
 > It should be impossible to build a slow website in Astro.
 
-I found this all to be true when I ran the PageSpeed test for my website. The [score](https://pagespeed.web.dev/report?url=https%3A%2F%2Fdominuskelvin.dev%2F) was unbelievable.
+I found this all to be true when I ran the PageSpeed test for my website. The [score](https://pagespeed.web.dev/report?url=https%3A%2F%2Fomereshone.com%2F) was unbelievable.
 
 ### Superb DX
 

--- a/src/pages/blog/starting-web-dev-professionally.md
+++ b/src/pages/blog/starting-web-dev-professionally.md
@@ -76,7 +76,7 @@ After leaving Fleet Device Management, I decided to be more intentional in build
 
 Doing so quickly got me from 500 to 10,000+ followers within the space of 4 months and this blew my mind.
 
-I had previously started a show on YouTube called [TKYT](https://dominuskelvin.dev/tkyt)(Teach Kelvin Your Thing) - a series where I invite people building technologies to teach me something for an hour. I’ve done over [30+ sessions](https://youtube.com/playlist?list=PL4qsujwiHvcP-a8z1--RyZ8XVFHbeBIfn) now.
+I had previously started a show on YouTube called [TKYT](https://omereshone.com/tkyt)(Teach Kelvin Your Thing) - a series where I invite people building technologies to teach me something for an hour. I’ve done over [30+ sessions](https://youtube.com/playlist?list=PL4qsujwiHvcP-a8z1--RyZ8XVFHbeBIfn) now.
 
 Also connecting with people for TKYT got me in touch with someone from the company I am currently a [JavaScript engineer and Developer Advocate](https://x.com/Dominus_Kelvin/status/1587844494749155329?s=20) at.
 
@@ -112,7 +112,7 @@ With how intuitive Vue is, I see it as a great framework to build a business of 
 
 In my opinion, JavaScript is an unfair advantage to build businesses on in terms of the technology stack.
 
-Join the [BBoJS newsletter](https://newsletter.dominuskelvin.dev) to get inspired by stories of people building businesses on JavaScript.
+Join the [BBoJS newsletter](https://newsletter.omereshone.com) to get inspired by stories of people building businesses on JavaScript.
 
 ## Conclusion
 

--- a/src/pages/blog/you-want-originality-too-early.md
+++ b/src/pages/blog/you-want-originality-too-early.md
@@ -378,7 +378,7 @@ If you are a writer, you should be rewriting great prose and feeling where your 
 
 If you are an engineer, you should be re-implementing systems you admire and learning where your thinking becomes fuzzy.
 
-If you are a founder, you should stop staring at headlines and start studying operational rhythm: how strong operators sequence decisions, [price products](https://dominuskelvin.dev/blog/build-globally-price-locally/), hire slowly, and build distribution.
+If you are a founder, you should stop staring at headlines and start studying operational rhythm: how strong operators sequence decisions, [price products](https://omereshone.com/blog/build-globally-price-locally/), hire slowly, and build distribution.
 
 In every case, the deeper lesson is the same: learn the process, not the performance.
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -132,7 +132,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../config'
               Let's talk!
             </p>
             <a
-              href="https://dominuskelvin.dev/deals"
+              href="https://omereshone.com/deals"
               target="_blank"
               class="inline-flex items-center text-sm font-medium text-purple-600 hover:text-purple-700"
             >
@@ -204,7 +204,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../config'
               great idea.
             </p>
             <a
-              href="https://sailscasts.com/courses?utm_source=dominuskelvin.dev"
+              href="https://sailscasts.com/courses?utm_source=omereshone.com"
               target="_blank"
               class="inline-flex items-center text-sm font-medium text-blue-600 hover:text-blue-700"
             >
@@ -239,7 +239,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../config'
               invoices.
             </p>
             <a
-              href="https://hagfish.io?utm_source=dominuskelvin.dev"
+              href="https://hagfish.io?utm_source=omereshone.com"
               target="_blank"
               class="inline-flex items-center text-sm font-medium text-orange-600 hover:text-orange-700"
             >
@@ -309,7 +309,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../config'
               A tool that lets you tinker with JavaScript in a fun way.
             </p>
             <a
-              href="https://guppy.sailscasts.com?utm_source=dominuskelvin.dev"
+              href="https://guppy.sailscasts.com?utm_source=omereshone.com"
               target="_blank"
               class="inline-flex items-center text-sm font-medium text-teal-600 hover:text-teal-700"
             >

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -6,7 +6,7 @@ import Footer from '../components/Footer.astro'
 const pageTitle = 'Music by Kelvin Omereshone | Hire for Sessions and Scores'
 const pageDescription =
   'Book Kelvin Omereshone for recording sessions, live keys, arrangement, film scoring, musical direction, and production support.'
-const contactEmail = 'music@dominuskelvin.dev'
+const contactEmail = 'music@omereshone.com'
 
 const services = [
   {
@@ -138,7 +138,7 @@ const mailtoHref = `mailto:${contactEmail}?subject=${encodeURIComponent(
     />
     <script is:inline>
       ;(() => {
-        const storageKey = 'dominuskelvin.music.currency'
+        const storageKey = 'omereshone.music.currency'
         const fallback = 'usd'
 
         const getUrlCurrency = () => {
@@ -727,7 +727,7 @@ const mailtoHref = `mailto:${contactEmail}?subject=${encodeURIComponent(
     <Footer compact />
 
     <script>
-      const storageKey = 'dominuskelvin.music.currency'
+      const storageKey = 'omereshone.music.currency'
       const buttons = document.querySelectorAll('[data-currency-button]')
       const rateOptions = document.querySelectorAll('[data-rate-option]')
       const quantityInput = document.querySelector('[data-estimate-quantity]')
@@ -866,7 +866,7 @@ Reference links or scene link:
 
 `
 
-          estimateMailto.href = `mailto:music@dominuskelvin.dev?subject=${encodeURIComponent(
+          estimateMailto.href = `mailto:music@omereshone.com?subject=${encodeURIComponent(
             subject,
           )}&body=${encodeURIComponent(body)}`
         }


### PR DESCRIPTION
## Summary
- update canonical Astro site URL, analytics domain, package metadata, and README references to omereshone.com
- update current site links, UTM sources, funding metadata, and music contact email
- preserve archival/social handle URLs that still point to external accounts

## Verification
- npm run build

Resolves #15